### PR TITLE
Add date range and MAC support

### DIFF
--- a/.github/workflows/create-nuget.yml
+++ b/.github/workflows/create-nuget.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       - name: Authenticate with Azure
         uses: azure/login@v1
         with:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-binary
-          path: .\SampleApp\bin\x64\Release\net8.0\win-x64\publish\RADIUSConsole.exe
+          path: .\SampleApp\bin\x64\Release\net10.0\win-x64\publish\RADIUSConsole.exe
 
   build-macos:
     name: Build client for macOS
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: macos-binary
-          path: ./SampleApp/bin/Release/net8.0/osx-x64/publish/RADIUSConsole
+          path: ./SampleApp/bin/Release/net10.0/osx-x64/publish/RADIUSConsole
 
   build-linux:
     name: Build client for Linux
@@ -72,7 +72,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: linux-binary
-          path: ./SampleApp/bin/Release/net8.0/linux-x64/publish/RADIUSConsole
+          path: ./SampleApp/bin/Release/net10.0/linux-x64/publish/RADIUSConsole
 
   create-release:
     name: Create release and upload binaries

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -12,16 +12,16 @@ env:
   GH_TOKEN: ${{ github.token }}
 jobs:
 
-  build:
-    runs-on: windows-latest  
+  build-windows:
+    name: Build client for Windows
+    runs-on: windows-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-      - run: gh release create ezradius-client-v${{ inputs.version }} --title "Certificate Renewal Client v${{ inputs.version }}"
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       - name: Authenticate with Azure
         uses: azure/login@v1
         with:
@@ -32,5 +32,70 @@ jobs:
         uses: microsoft/setup-msbuild@v2
       - name: Run Powershell Script 
         run: .\SampleApp\buildAndSign.ps1
-      - name: Upload Artifacts
-        run: gh release upload ezradius-client-v${{ inputs.version }} .\SampleApp\bin\x64\Release\net8.0\win-x64\publish\RADIUSConsole.exe
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-binary
+          path: .\SampleApp\bin\x64\Release\net8.0\win-x64\publish\RADIUSConsole.exe
+
+  build-macos:
+    name: Build client for macOS
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Set up .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: Publish macOS binary
+        run: dotnet publish ./SampleApp/SampleApp.csproj -c Release -r osx-x64 --self-contained true /p:PublishSingleFile=true
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-binary
+          path: ./SampleApp/bin/Release/net8.0/osx-x64/publish/RADIUSConsole
+
+  build-linux:
+    name: Build client for Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Set up .NET Core
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+      - name: Publish Linux binary
+        run: dotnet publish ./SampleApp/SampleApp.csproj -c Release -r linux-x64 --self-contained true /p:PublishSingleFile=true
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-binary
+          path: ./SampleApp/bin/Release/net8.0/linux-x64/publish/RADIUSConsole
+
+  create-release:
+    name: Create release and upload binaries
+    runs-on: ubuntu-latest
+    needs: [build-windows, build-macos, build-linux]
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Create GitHub Release
+        run: gh release create ezradius-client-v${{ inputs.version }} --title "Certificate Renewal Client v${{ inputs.version }}" --repo ${{ github.repository }}
+
+      - name: Upload Windows binary
+        run: gh release upload ezradius-client-v${{ inputs.version }} ./artifacts/windows-binary/RADIUSConsole.exe --repo ${{ github.repository }}
+
+      - name: Upload macOS binary
+        run: |
+          mv ./artifacts/macos-binary/RADIUSConsole ./artifacts/macos-binary/RADIUSConsole-macos-x64
+          gh release upload ezradius-client-v${{ inputs.version }} ./artifacts/macos-binary/RADIUSConsole-macos-x64 --repo ${{ github.repository }}
+
+      - name: Upload Linux binary
+        run: |
+          mv ./artifacts/linux-binary/RADIUSConsole ./artifacts/linux-binary/RADIUSConsole-linux-x64
+          gh release upload ezradius-client-v${{ inputs.version }} ./artifacts/linux-binary/RADIUSConsole-linux-x64 --repo ${{ github.repository }}

--- a/EZRadiusClient/EZRadiusClient.csproj
+++ b/EZRadiusClient/EZRadiusClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -27,11 +27,11 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="Azure.Identity" Version="1.14.0" />
+      <PackageReference Include="Azure.Identity" Version="1.21.0" />
       <PackageReference Include="CommandLineParser" Version="2.9.1" />
       <PackageReference Include="CsvHelper" Version="33.1.0" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
-      <PackageReference Include="Polly" Version="8.5.2" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+      <PackageReference Include="Polly" Version="8.7.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/EZRadiusClient/Managers/EZRadiusManager.cs
+++ b/EZRadiusClient/Managers/EZRadiusManager.cs
@@ -187,7 +187,7 @@ public class EZRadiusManager : IEZRadiusManager
             }
             List<AuthenticationEventModel> authenticationEvents = new();
             authenticationEvents.AddRange(authenticationLogs);
-            while (authenticationLogs.Count >= auditRequest.MaxNumberOfRecords)
+            while (authenticationLogs.Count >= (auditRequest.MaxNumberOfRecords *.80))
             {
                 auditRequest.PageNumber += 1;
                 payload = JsonSerializer.Serialize(auditRequest);
@@ -206,7 +206,9 @@ public class EZRadiusManager : IEZRadiusManager
                     authenticationEvents.AddRange(authenticationLogs);
                 }
             }
-            return authenticationEvents;
+            return authenticationEvents
+                .DistinctBy(x => (x.DateCreated, x.UserName))
+                .ToList();
         }
         throw new HttpRequestException(
             "Error getting auth logs" + getAuthAuditLogsResponse.Message

--- a/EZRadiusClient/Models/TimeFrameModel.cs
+++ b/EZRadiusClient/Models/TimeFrameModel.cs
@@ -10,6 +10,12 @@ public class TimeFrameModel
         DateTo = DateTime.Now;
     }
 
+    public TimeFrameModel(DateTime dateFrom, DateTime dateTo)
+    {
+        DateFrom = dateFrom;
+        DateTo = dateTo;
+    }
+
     [JsonPropertyName("DateFrom")]
     public DateTime DateFrom { get; set; }
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Sample Call: ```.\RADIUSConsole.exe delete -s <scope_id> -u <instance_url> -a <a
 
 ## Displaying Authorization Logs
 
-Similar to the displaying Radius policies, this command gets authentication logs and displays them to the console. It uses the ```GetAuthAuditLogsAsync()``` method to get the logs from the EZRadius instance, and prints information about each log to the terminal. To run this command, use the verb ```getlogs```. The SampleApp is configured to return logs for the previous 2 days; to change this see ```TimeFrameModel``` in the EZRadiusClient directory.
+Similar to displaying Radius policies, this command gets authentication logs and displays them to the console. It uses the ```GetAuthAuditLogsAsync()``` method to get the logs from the EZRadius instance, and prints information about each log to the terminal. To run this command, use the verb ```getlogs```. You can pass either a relative range using days, or an explicit date range using from/to.
 
 ```
     -s, --scope           The token scope for the EZRadius instance. (Default: https://management.core.windows.net/.default) 
@@ -96,8 +96,12 @@ Similar to the displaying Radius policies, this command gets authentication logs
     
     -l, --log            The Azure Application Insights connection string. (Optional)
     
-    -d, --days           The number of days to get logs from. (Required)
+    -d, --days           The number of days to look back from now. (Optional, mutually exclusive with --from/--to)
+    --from               Start date/time for explicit range (example: 2026-01-01 or 2026-01-01T00:00:00)
+    --to                 End date/time for explicit range (example: 2026-01-31 or 2026-01-31T23:59:59)
     -f, --file           Path to save the logs to a  csv file. If not provided, logs will be printed to console.
 ```
 
-Sample Call: ```.\RADIUSConsole.exe getlogs -s <scope_id> -u <instance_url> -a <ad_url> -l <insight_connection_string> -d <number_of_days>```
+Sample Call (days lookback): ```.RADIUSConsole.exe getlogs -s <scope_id> -u <instance_url> -a <ad_url> -l <insight_connection_string> -d <number_of_days>```
+
+Sample Call (explicit date range): ```.RADIUSConsole.exe getlogs -s <scope_id> -u <instance_url> -a <ad_url> -l <insight_connection_string> --from <from_date> --to <to_date>```

--- a/README.md
+++ b/README.md
@@ -102,6 +102,6 @@ Similar to displaying Radius policies, this command gets authentication logs and
     -f, --file           Path to save the logs to a  csv file. If not provided, logs will be printed to console.
 ```
 
-Sample Call (days lookback): ```.RADIUSConsole.exe getlogs -s <scope_id> -u <instance_url> -a <ad_url> -l <insight_connection_string> -d <number_of_days>```
+Sample Call (days lookback): ```.\RADIUSConsole.exe getlogs -s <scope_id> -u <instance_url> -a <ad_url> -l <insight_connection_string> -d <number_of_days>```
 
-Sample Call (explicit date range): ```.RADIUSConsole.exe getlogs -s <scope_id> -u <instance_url> -a <ad_url> -l <insight_connection_string> --from <from_date> --to <to_date>```
+Sample Call (explicit date range): ```.\RADIUSConsole.exe getlogs -s <scope_id> -u <instance_url> -a <ad_url> -l <insight_connection_string> --from <from_date> --to <to_date>```

--- a/SampleApp/Managers/RadiusAppManager.cs
+++ b/SampleApp/Managers/RadiusAppManager.cs
@@ -217,21 +217,15 @@ public class RadiusAppManager
         parameters = InputService.ValidateArguments(parameters);
         IEZRadiusManager ezRadiusClient = InitializeEzRadiusManager(parameters);
 
-        if (!parameters.Days.HasValue)
+        if (!TryBuildTimeFrame(parameters, out TimeFrameModel? timeFrame, out string description, out string validationError))
         {
-            Console.WriteLine(
-                "Missing Days argument. Please provide a number of days to get audit logs for."
-            );
+            Console.WriteLine(validationError);
             return 1;
         }
 
-        TimeFrameModel timeFrame = new(parameters.Days.Value);
-
         try
         {
-            Console.WriteLine(
-                $"Getting Authentication Audit Logs for past {parameters.Days.Value} days..."
-            );
+            Console.WriteLine($"Getting Authentication Audit Logs for {description}...");
             List<AuthenticationEventModel> getAuditLogsResult =
                 await ezRadiusClient.GetAuthAuditLogsAsync(timeFrame);
             Console.WriteLine($"Found {getAuditLogsResult.Count} logs");
@@ -273,6 +267,75 @@ public class RadiusAppManager
             Console.WriteLine(e.Message);
             return 1;
         }
+    }
+
+    private static bool TryBuildTimeFrame(
+        ArgumentsModel parameters,
+        out TimeFrameModel? timeFrame,
+        out string description,
+        out string validationError
+    )
+    {
+        timeFrame = null;
+        description = string.Empty;
+        validationError = string.Empty;
+
+        bool hasDays = parameters.Days.HasValue;
+        bool hasFrom = !string.IsNullOrWhiteSpace(parameters.DateFrom);
+        bool hasTo = !string.IsNullOrWhiteSpace(parameters.DateTo);
+
+        if (hasDays && (hasFrom || hasTo))
+        {
+            validationError = "Use either --days or --from/--to, not both.";
+            return false;
+        }
+
+        if (hasDays)
+        {
+            if (parameters.Days <= 0)
+            {
+                validationError = "--days must be greater than 0.";
+                return false;
+            }
+
+            timeFrame = new TimeFrameModel(parameters.Days.Value);
+            description = $"the past {parameters.Days.Value} days";
+            return true;
+        }
+
+        if (hasFrom ^ hasTo)
+        {
+            validationError = "When using a date range, both --from and --to are required.";
+            return false;
+        }
+
+        if (!(hasFrom && hasTo))
+        {
+            validationError = "Provide either --days <n> or --from <date> --to <date>.";
+            return false;
+        }
+
+        if (!DateTime.TryParse(parameters.DateFrom, out DateTime parsedFrom))
+        {
+            validationError = "Invalid --from value. Use a valid date/time such as 2026-01-01 or 2026-01-01T00:00:00.";
+            return false;
+        }
+
+        if (!DateTime.TryParse(parameters.DateTo, out DateTime parsedTo))
+        {
+            validationError = "Invalid --to value. Use a valid date/time such as 2026-01-31 or 2026-01-31T23:59:59.";
+            return false;
+        }
+
+        if (parsedFrom > parsedTo)
+        {
+            validationError = "--from must be earlier than or equal to --to.";
+            return false;
+        }
+
+        timeFrame = new TimeFrameModel(parsedFrom, parsedTo);
+        description = $"{parsedFrom:u} to {parsedTo:u}";
+        return true;
     }
 
     private async Task<List<RadiusPolicyModel>> GetRadiusPoliciesAsync(

--- a/SampleApp/Managers/RadiusAppManager.cs
+++ b/SampleApp/Managers/RadiusAppManager.cs
@@ -315,13 +315,27 @@ public class RadiusAppManager
             return false;
         }
 
-        if (!DateTime.TryParse(parameters.DateFrom, out DateTime parsedFrom))
+        if (
+            !DateTimeOffset.TryParse(
+                parameters.DateFrom,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out DateTimeOffset parsedFrom
+            )
+        )
         {
             validationError = "Invalid --from value. Use a valid date/time such as 2026-01-01 or 2026-01-01T00:00:00.";
             return false;
         }
 
-        if (!DateTime.TryParse(parameters.DateTo, out DateTime parsedTo))
+        if (
+            !DateTimeOffset.TryParse(
+                parameters.DateTo,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out DateTimeOffset parsedTo
+            )
+        )
         {
             validationError = "Invalid --to value. Use a valid date/time such as 2026-01-31 or 2026-01-31T23:59:59.";
             return false;
@@ -333,8 +347,8 @@ public class RadiusAppManager
             return false;
         }
 
-        timeFrame = new TimeFrameModel(parsedFrom, parsedTo);
-        description = $"{parsedFrom:u} to {parsedTo:u}";
+        timeFrame = new TimeFrameModel(parsedFrom.UtcDateTime, parsedTo.UtcDateTime);
+        description = $"{parsedFrom.UtcDateTime:u} to {parsedTo.UtcDateTime:u}";
         return true;
     }
 

--- a/SampleApp/Models/ArgumentsModel.cs
+++ b/SampleApp/Models/ArgumentsModel.cs
@@ -46,6 +46,8 @@ public class ArgumentsModel
         ADUrl = arguments.ADUrl;
         AppInsightConnection = arguments.AppInsightConnection;
         Days = arguments.Days;
+        DateFrom = arguments.DateFrom;
+        DateTo = arguments.DateTo;
         CsvFilePath = arguments.FileName;
     }
 
@@ -60,6 +62,10 @@ public class ArgumentsModel
     public string? CsvFilePath { get; set; }
 
     public int? Days { get; set; }
+
+    public string? DateFrom { get; set; }
+
+    public string? DateTo { get; set; }
 
     public string? PolicyName { get; set; }
 }

--- a/SampleApp/Models/GetAuditLogsArgModel.cs
+++ b/SampleApp/Models/GetAuditLogsArgModel.cs
@@ -32,8 +32,22 @@ public class GetAuditLogsArgModel
     )]
     public string ADUrl { get; set; } = string.Empty;
 
-    [Option('d', "days", Required = true, HelpText = "Number of days to fetch logs for")]
-    public int Days { get; set; }
+    [Option('d', "days", Required = false, HelpText = "Number of days to fetch logs for")]
+    public int? Days { get; set; }
+
+    [Option(
+        "from",
+        Required = false,
+        HelpText = "Start date/time for log range (for example: 2026-01-01 or 2026-01-01T00:00:00)"
+    )]
+    public string? DateFrom { get; set; }
+
+    [Option(
+        "to",
+        Required = false,
+        HelpText = "End date/time for log range (for example: 2026-01-31 or 2026-01-31T23:59:59)"
+    )]
+    public string? DateTo { get; set; }
 
     [Option(
         'f',

--- a/SampleApp/Properties/launchSettings.json
+++ b/SampleApp/Properties/launchSettings.json
@@ -2,7 +2,11 @@
   "profiles": {
     "SampleApp": {
       "commandName": "Project",
-      "commandLineArgs": "getlogs --url https://localhost:5003 -d 35 -f test.csv"
+      "commandLineArgs": "getlogs --url https://usa.east.test-slot.ezradius.io -d 35 -f test.csv"
+    },
+    "DateRange": {
+      "commandName": "Project",
+      "commandLineArgs": "getlogs --url https://usa.east.test-slot.ezradius.io --from 2026-06-20 --to 2026-06-26 -f test.csv"
     }
   }
 }

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AssemblyName>RADIUSConsole</AssemblyName>
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Azure.Identity" Version="1.14.0" />
+      <PackageReference Include="Azure.Identity" Version="1.21.0" />
       <PackageReference Include="CommandLineParser" Version="2.9.1" />
       <PackageReference Include="CsvHelper" Version="33.1.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />


### PR DESCRIPTION
Introduce support for specifying a date range in log retrieval, allowing users to fetch logs based on explicit start and end dates. Update the application to use .NET 10.0 and enhance the command-line interface for better usability.